### PR TITLE
empty bucket before destroy to improve destroy time

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,5 +81,14 @@ resource "aws_s3_bucket" "quortex" {
   acl           = "private"
   force_destroy = var.force_destroy
   tags          = var.tags
-}
 
+  # Empty bucket content before destroy to improves the bucket destruction time
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<EOT
+      ${!self.force_destroy} && exit
+      echo 'emptying ${self.bucket} bucket'
+      aws s3 rm s3://${self.bucket} --recursive --quiet
+    EOT
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "sa_path" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "Tags to apply to resources. A list of key->value pairs."
   default     = {}
 }


### PR DESCRIPTION
This feature makes it possible to empty the buckets of their objects before destruction in order to optimize the time required for the destruction of the buckets.
Destroying a bucket containing 156,767 files took 15m25s