### PR TITLE
Remove S3 ACLs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,13 +97,6 @@ resource "aws_s3_bucket" "quortex" {
   }
 }
 
-resource "aws_s3_bucket_acl" "quortex" {
-  for_each = local.buckets
-
-  bucket = aws_s3_bucket.quortex[each.key].id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "quortex" {
   for_each = { for k, v in local.buckets : k => v if try(v.expiration.enabled, false) }
 


### PR DESCRIPTION
With the latest default policy change ACLs are disable & Block Public Access enable by default.
We have to remove ACLs on creation.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-faq.html